### PR TITLE
Add basic meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,4 @@
+project('fest', 'rust')
+
+subdir('src')
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,3 @@
+cargo = import('unstable-cargo')
+cargo.executable('fest-im', toml: '../Cargo.toml', install: true)
+


### PR DESCRIPTION
This relies on the unstable-cargo module, which has yet to be
upstreamed. See: https://github.com/mesonbuild/meson/pull/2617